### PR TITLE
Removing note that previous backups for MSO365 groups not available

### DIFF
--- a/task_managing_restores.adoc
+++ b/task_managing_restores.adoc
@@ -185,7 +185,7 @@ Within Microsoft SharePoint Online, you can restore granular-level items for a s
       .. Click *View the job progress* to monitor the progress of the restore.
 
 == Restoring from a previous backup
-By default, only your most recent backup is available for restore. *Note*: Previous backups of Microsoft Office 365 group sites are not available for restore.
+By default, only your most recent backup is available for restore.
 
 .Steps
 


### PR DESCRIPTION
Removing note that previous backups for O365 groups not available.  Previous backups for groups is available.